### PR TITLE
Remove duplicate returns

### DIFF
--- a/Lab Files/Bresenham_Line.cpp
+++ b/Lab Files/Bresenham_Line.cpp
@@ -53,7 +53,6 @@ int main(){
     closegraph();
     return 0;
 
-return 0;
 }
 
 

--- a/Lab Files/DDA.cpp
+++ b/Lab Files/DDA.cpp
@@ -52,5 +52,4 @@ int main(){
     closegraph();
     return 0;
 
-return 0;
 }

--- a/Lab Files/Direct_Equation.cpp
+++ b/Lab Files/Direct_Equation.cpp
@@ -65,6 +65,5 @@ int main(){
     closegraph();
     return 0;
 
-return 0;
 }
 

--- a/Lab Files/Mid-Point.cpp
+++ b/Lab Files/Mid-Point.cpp
@@ -54,7 +54,6 @@ int main(){
     closegraph();
     return 0;
 
-return 0;
 }
 
 


### PR DESCRIPTION
## Summary
- fix duplicate `return 0;` statements in drawing example code

## Testing
- `grep -n "return 0;" 'Lab Files'/*.cpp`